### PR TITLE
improve semantic labeling for requestBody field

### DIFF
--- a/__tests__/react.js
+++ b/__tests__/react.js
@@ -143,9 +143,10 @@ describe('Unit testing "RequestBody" component', () => {
   let store;
   beforeEach(() => {
     store = mockStore(initialState);
+    const state = store.getState();
     render(
       <Provider store={store}>
-        <RequestBody />
+        <RequestBody showField = {state.testForm.requestType === 'Get' ? false : true} />
       </Provider>
     );
   });

--- a/__tests__/testMiddleReducer.js
+++ b/__tests__/testMiddleReducer.js
@@ -11,7 +11,6 @@ describe('Test Middle Reducer', () => {
         assertionList: {},
         i: 0,
         userInput: '',
-        inputType: 'Status Code',
       };
     });
     describe('default state', () => {

--- a/client/components/Header.jsx
+++ b/client/components/Header.jsx
@@ -57,7 +57,7 @@ export const Header = () => {
           id={requestType}
           name={requestType}
         />
-        <RequestBody requestType={requestType} />
+        <RequestBody showField={requestType === 'Get' ? false : true} />
       </span>
       <Box id="assertion-list">Assertion List: {assertionList}</Box>
       <Button

--- a/client/components/RequestBody.jsx
+++ b/client/components/RequestBody.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TextField } from '@mui/material';
 
 export const RequestBody = (props) => {
-  if (props.requestType !== 'Get') {
+  if (props.showField) {
     return (
       <TextField label="Request Body" id="Request-Body" data-testid="Request-Body" name="Request-Body" />
     );


### PR DESCRIPTION
**This PR will:**

- Improve semantic labeling in header component for rendering of requestBody component when request type not equal to 'Get'
- Fix tests to reflect change